### PR TITLE
Use db for Remotive data

### DIFF
--- a/backend/sprocs.py
+++ b/backend/sprocs.py
@@ -1,0 +1,147 @@
+from pathlib import Path
+from datetime import datetime, timezone
+import sqlite3
+
+from utils.sql.models import JobPosting
+
+
+def get_connection(db_filename) -> sqlite3.Connection:
+    # Get the absolute path to Job.db
+    db_file = str(Path.cwd().resolve().joinpath("data").joinpath(f"{db_filename}"))
+    return sqlite3.connect(db_file)
+
+
+def get_all_job_postings(db_filename) -> str:
+    """_summary_
+
+    Args:
+        db_filename (_type_): _description_
+
+    Returns:
+        str: _description_
+    """
+    print("Getting connection to db...")
+    conn = get_connection(db_filename)
+    with conn:
+        cursor = conn.cursor()
+
+        print("Executing getAllJobPostings sproc...")
+        cursor.execute(
+            """
+            SELECT
+                p.id,
+                category,
+                company_name,
+                job_title,
+                description,
+                salary,
+                STRING_AGG(t.name, ', ') AS tags,
+                job_type,
+                source_url,
+                publish_date
+                FROM postings p
+                    JOIN tags t ON t.id = p.tag_id
+                WHERE p.inactive_date_utc IS NOT NULL
+                GROUP BY
+                p.id,
+                category,
+                company_name,
+                job_title,
+                description,
+                salary,
+                job_type,
+                source_url,
+                publish_date
+            """
+        )
+        postings = [
+            JobPosting(
+                id=row[0],
+                category=row[1],
+                company_name=row[2],
+                job_title=row[3],
+                description = row[4],
+                salary=row[5],
+                tags=row[6],
+                job_type=row[7],
+                source_url=row[8],
+                publish_date=row[9],
+            )
+            for row in cursor.fetchall()
+        ]
+
+    print(f"getAllJobPostings returned {len(postings)} records.")
+    return postings
+
+
+def get_job_postings_by_category(categories: str, db_filename: str) -> str:
+    """_summary_
+
+    Args:
+        categories (str): _description_
+        db_filename (str): _description_
+
+    Returns:
+        str: _description_
+    """
+    items = [item.strip() for item in categories.split(",")]
+    category_req = ", ".join(f"'{item}'" for item in items)
+
+    print("Getting connection to db...")
+    conn = get_connection(db_filename)
+    with conn:
+        cursor = conn.cursor()
+
+        print(f"Executing getJobPostingsByCategory, ({category_req}) sproc...")
+        query = (
+            f"""
+            SELECT
+                p.id,
+                category,
+                company_name,
+                job_title,
+                description,
+                salary,
+                STRING_AGG(t.name, ', ') AS tags,
+                job_type,
+                source_url,
+                publish_date
+                FROM postings p
+                    JOIN tags t ON t.id = p.tag_id
+                WHERE p.inactive_date_utc IS NOT NULL
+                AND category IN ({category_req})
+                GROUP BY
+                p.id,
+                category,
+                company_name,
+                job_title,
+                description,
+                salary,
+                job_type,
+                source_url,
+                publish_date
+            """
+        )
+        print(query)
+        cursor.execute(query)
+        postings = [
+            JobPosting(
+                id=row[0],
+                category=row[1],
+                company_name=row[2],
+                job_title=row[3],
+                description = row[4],
+                salary=row[5],
+                tags=row[6],
+                job_type=row[7],
+                source_url=row[8],
+                publish_date=row[9],
+            )
+            for row in cursor.fetchall()
+        ]
+
+    print(f"getJobPostingsByCategory returned {len(postings)} records.")
+    return postings
+
+
+print(get_all_job_postings("Job.db"))

--- a/backend/utils/sql/models.py
+++ b/backend/utils/sql/models.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+@dataclass
+class JobPosting:
+    id: int
+    job_title: str
+    description: str
+    category: str
+    company_name: str
+    salary: str
+    tags: str
+    job_type: str
+    source_url: str
+    publish_date: str

--- a/backend/utils/sql/sql.py
+++ b/backend/utils/sql/sql.py
@@ -1,9 +1,10 @@
-import sqlite3
-import pandas as pd
 from pathlib import Path
 from datetime import datetime, timezone
+import sqlite3
+import pandas as pd
 
 from utils.sql.make_db import init_tables
+
 
 def insert_new_sources(df: pd.DataFrame, conn: sqlite3.Connection) -> None:
     """Adds new sources to the sources table with new PK


### PR DESCRIPTION
This PR will allow us to call data from the db rather than a direct Remotive API hit.

- Uses a sprocs.py file for db stored procedures (SPROCS)
- Adds a datamodel (object) for our job postings
- Adjusts imports to follow Python import standards
  1. Standard library imports
  2. Third-party library imports
  3. Local application/library specific imports