### PR TITLE
Run backend with gunicorn script

### DIFF
--- a/backend/fetch_external_data.py
+++ b/backend/fetch_external_data.py
@@ -120,8 +120,7 @@ def fetch_external_data(api_sources: Path) -> pd.DataFrame:
         for line in data_src_fh.readlines():
             src_data = line.split(",")
             src, url = src_data
-            match src:
-                case "remotive":
-                    jobs_df = get_remotive_jobs(url)
+            if src == "remotive":
+                jobs_df = get_remotive_jobs(url)
 
     return jobs_df

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,7 +14,6 @@ MarkupSafe==2.1.5
 numpy==2.0.0
 pandas==2.2.2
 pyarrow==16.1.0
-pyenv==0.0.1
 python-dateutil==2.9.0.post0
 pytz==2024.1
 requests==2.32.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ charset-normalizer==3.3.2
 click==8.1.7
 Flask==3.0.3
 Flask-Cors==4.0.0
+gunicorn==22.0.0
 idna==3.7
 itsdangerous==2.2.0
 Jinja2==3.1.4
@@ -13,6 +14,7 @@ MarkupSafe==2.1.5
 numpy==2.0.0
 pandas==2.2.2
 pyarrow==16.1.0
+pyenv==0.0.1
 python-dateutil==2.9.0.post0
 pytz==2024.1
 requests==2.32.3

--- a/backend/run_backend
+++ b/backend/run_backend
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+# Check if a port number is provided
+if [ $# -eq 0 ]; then
+    echo "No port number supplied. Usage: ./run_backend.sh <port>"
+    exit 1
+fi
+
+PORT=$1 # Get the specified port
+
+echo "Building envirnoment and gathering all dependencies..."
+chmod +x build_backend_env
+./build_backend_env
+
+echo "Activating environment..."
+source .venv/bin/activate
+
+# Start Gunicorn
+echo "Starting Gunicorn..."
+gunicorn -w 4 -b "0.0.0.0:$PORT" app:app


### PR DESCRIPTION
Adds a bash helper to properly build the backend env, activate as a venv, and serve with gunicorn on a requested port.